### PR TITLE
Add support for loud comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@ import postcss from 'postcss';
 
 const postcssFlexibility = postcss.plugin('postcss-flexibility', () => css => {
 	css.walkRules(rule => {
-		const isDisabled = rule.some(({prop, text}) =>
-			prop === '-js-display' || text === 'flexibility-disable' || text === '! flexibility-disable'
+		const isDisabled = rule.some(({prop, text = ''}) =>
+			prop === '-js-display' || text.endsWith('flexibility-disable')
 		);
 
 		if (!isDisabled) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import postcss from 'postcss';
 const postcssFlexibility = postcss.plugin('postcss-flexibility', () => css => {
 	css.walkRules(rule => {
 		const isDisabled = rule.some(({prop, text}) =>
-			prop === '-js-display' || text === 'flexibility-disable'
+			prop === '-js-display' || text === 'flexibility-disable' || text === '! flexibility-disable'
 		);
 
 		if (!isDisabled) {

--- a/test.js
+++ b/test.js
@@ -51,3 +51,17 @@ test('Don\'add "-js-display: flex" if comment "flexibility-disable" is exist', t
 		}`
 	);
 });
+
+test('Don\'add "-js-display: flex" if comment "! flexibility-disable" is exist', t => {
+	return run(
+		t,
+		`a {
+			/*! flexibility-disable */
+			display: flex;
+		}`,
+		`a {
+			/*! flexibility-disable */
+			display: flex;
+		}`
+	);
+});


### PR DESCRIPTION
It is very important the add support for loud comments when working in production environments since normal comments are removed when compiling sass with as compressed.